### PR TITLE
Rspec before describe call in controller template

### DIFF
--- a/lib/generators/templates/controller/controller_spec_template.erb
+++ b/lib/generators/templates/controller/controller_spec_template.erb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe <%= @controller.controller %>, regressor: true do
+RSpec.describe <%= @controller.controller %>, regressor: true do
   # === Routes (REST) ===
   <%= @controller.rest_routes %>
   # === Callbacks (Before) ===


### PR DESCRIPTION
Call `describe` in controller regression spec the same way its done in [spec_regression_template.erb](https://github.com/ndea/regressor/blob/master/lib/generators/templates/spec_regression_template.erb#L3) 
