### PR TITLE
Allow for classes to be used as filters

### DIFF
--- a/lib/controller/callback/after_filter.rb
+++ b/lib/controller/callback/after_filter.rb
@@ -4,7 +4,7 @@ module Regressor
       module AfterFilter
         def after_callbacks
           after_filters.map do |filter_name|
-            "it { should use_after_filter(:#{filter_name}) }"
+            "it { should use_after_filter(#{filter_name}) }"
           end.compact.uniq.join("\n  ")
         end
       end

--- a/lib/controller/callback/around_filter.rb
+++ b/lib/controller/callback/around_filter.rb
@@ -4,7 +4,7 @@ module Regressor
       module AroundFilter
         def around_callbacks
           around_filters.map do |filter_name|
-            "it { should use_around_filter(:#{filter_name}) }"
+            "it { should use_around_filter(#{filter_name}) }"
           end.compact.uniq.join("\n  ")
         end
       end

--- a/lib/controller/callback/before_filter.rb
+++ b/lib/controller/callback/before_filter.rb
@@ -4,7 +4,7 @@ module Regressor
       module BeforeFilter
         def before_callbacks
           before_filters.map do |filter_name|
-            "it { should use_before_filter(:#{filter_name}) }"
+            "it { should use_before_filter(#{filter_name}) }"
           end.compact.uniq.join("\n  ")
         end
       end

--- a/lib/controller/util.rb
+++ b/lib/controller/util.rb
@@ -20,7 +20,8 @@ module Regressor
         all_filters = controller._process_action_callbacks
         all_filters = all_filters.select { |f| f.kind == kind } if kind
         # Reject procs
-        all_filters.map(&:raw_filter).reject{|filter| filter.class == Proc}
+        all_filters = all_filters.map(&:raw_filter).reject{|filter| filter.class == Proc}
+        all_filters.map {|filter| filter.is_a?(Symbol) ? ":#{filter}" : filter.to_s}
       end
     end
   end


### PR DESCRIPTION
Using ":" in front of the raw_filter name on callbacks only if the filter is a Symbol, otherwise use just raw_filter.to_s.

Resolves #17 
