### PR TITLE
Fix the routing test generator for Rails 5

### DIFF
--- a/lib/controller/routing/rest/routes.rb
+++ b/lib/controller/routing/rest/routes.rb
@@ -9,30 +9,53 @@ module Regressor
             @controller.constantize.action_methods.map do |action_method|
               begin
                 journey_route = extract_journey_route(controller_path, action_method)
+                unless journey_route
+                  puts "Skip generating regression spec for controller #{controller_path} with action: #{action_method}" unless ENV['QUIET']
+                  next
+                end
                 required_parts = extract_required_parts(journey_route)
                 url = url_for({controller: controller_path, action: action_method, only_path: true}.merge(required_parts))
                 generate_example(journey_route, controller_path, action_method, required_parts, url)
               rescue
-                puts "Could not generate regression spec for controller #{controller_path} with action: #{action_method}"
+                puts "Failed to generate regression spec for controller #{controller_path} with action: #{action_method}. #{$!.class}: #{$!.message}"
                 nil
               end
             end.uniq.compact.join("\n  ")
           end
 
           private
-
-          def generate_example(journey_route, controller_path, action_method, required_parts, url)
-            request_method = journey_route.constraints[:request_method]
-            if request_method.match('GET')
-              "it { should route(:get, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) }"
-            elsif request_method.match('POST')
-              "it { should route(:post, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
-            elsif request_method.match('PUT')
-              "it { should route(:put, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
-            elsif request_method.match('PATCH')
-              "it { should route(:patch, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
-            elsif request_method.match('DELETE')
-              "it { should route(:delete, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+          
+          if Rails::VERSION::MAJOR >= 5
+            def generate_example(journey_route, controller_path, action_method, required_parts, url)
+              case journey_route.verb
+              when 'GET'
+                "it { should route(:get, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) }"
+              when 'POST'
+                "it { should route(:post, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              when 'PUT'
+                "it { should route(:put, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              when 'PATCH'
+                "it { should route(:patch, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              when 'DELETE'
+                "it { should route(:delete, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              end
+            end
+            
+          else
+            
+            def generate_example(journey_route, controller_path, action_method, required_parts, url)
+              request_method = journey_route.constraints[:request_method]
+              if request_method.match('GET')
+                "it { should route(:get, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) }"
+              elsif request_method.match('POST')
+                "it { should route(:post, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              elsif request_method.match('PUT')
+                "it { should route(:put, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              elsif request_method.match('PATCH')
+                "it { should route(:patch, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              elsif request_method.match('DELETE')
+                "it { should route(:delete, '#{url}').to('#{controller_path}##{action_method}', #{required_parts}) } "
+              end
             end
           end
 

--- a/lib/templates/controller/controller_spec_template.erb
+++ b/lib/templates/controller/controller_spec_template.erb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe <%= @controller.controller %>, regressor: true do
+RSpec.describe <%= @controller.controller %>, regressor: true, type: :routing do
   # === Routes (REST) ===
   <%= @controller.rest_routes %>
   # === Callbacks (Before) ===


### PR DESCRIPTION
And make feedback more informative when this generator fails.
With QUIET=1 env var, don't even mention unrouted actions like `current_user`.