### PR TITLE
model generators accept optional list of models

### DIFF
--- a/lib/generators/regressor/model_generator.rb
+++ b/lib/generators/regressor/model_generator.rb
@@ -4,6 +4,9 @@ module Regressor
   class ModelGenerator < ::Rails::Generators::Base
     source_root(File.expand_path(File.dirname(__FILE__)))
 
+    argument :models, type: :array, default: [], banner: "models"
+
+    desc 'Create regression specs for activerecord models.'
     def create_regression_files
       load_application
       generate_ar_specs
@@ -27,7 +30,9 @@ module Regressor
 
     def load_ar_models
       if defined?(::ActiveRecord::Base)
-        ActiveRecord::Base.descendants.map(&:name).reject { |x| Regressor.configuration.excluded_models.include? x }
+        ar_models = ActiveRecord::Base.descendants.map(&:name)
+        ar_models &= models.map(&:classify) if models.present?
+        ar_models.reject { |x| Regressor.configuration.excluded_models.include? x }
       else
         []
       end


### PR DESCRIPTION
Adds an optional argument `models` to the activerecord and mongoid generator. The generators will only create/update the regression specs for the models specified, or all if no model names are specified. 
Also adds a short description to the model spec generators.