### PR TITLE
Update Gem Fake to 2.19.x

### DIFF
--- a/regressor.gemspec
+++ b/regressor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency 'shoulda-matchers'
-  s.add_dependency 'faker', '~> 1.9'
+  s.add_dependency 'faker', '~> 2.19'
   s.add_dependency 'rails'
 
   s.add_development_dependency 'sqlite3', '~> 1.3.0', '>= 1.3.0'


### PR DESCRIPTION
Because of the last Rails update to version 7, the Fake gem needed to be updated to the latest version.